### PR TITLE
An object's owner should be the user making the request

### DIFF
--- a/metpetdb_api/api/lib/serializers.py
+++ b/metpetdb_api/api/lib/serializers.py
@@ -11,6 +11,17 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
         # Instantiate the superclass normally
         super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
 
+        if self.context.get('request'):
+            if self.context['request'].method == 'POST':
+                # An object's owner should be the user making the request;
+                # objects which don't have an owner can just ignore this
+                self.context['request'].data['owner'] = str(
+                    self.context['request'].user.pk
+                )
+            elif self.context['request'].method == 'PUT':
+                # Don't allow PUT operations to update an object's owner
+                self.context['request'].data.pop('owner', None)
+
         try:
             fields = self.context['request'].query_params.get('fields')
         except KeyError:
@@ -18,7 +29,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
 
         if fields:
             fields = fields.split(',')
-            # Drop any fields that are not specified in the `fields` argument.
+            # Drop any fields that are not specified in the `fields` argument
             allowed = set(fields)
             existing = set(self.fields.keys())
             for field_name in existing - allowed:

--- a/metpetdb_api/api/samples/v1/tests.py
+++ b/metpetdb_api/api/samples/v1/tests.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-
 from apps.samples.models import (
     GeoReference,
     MetamorphicGrade,
@@ -15,9 +14,11 @@ from apps.samples.models import (
 )
 from apps.users.models import User
 
+
 def get_random_str(length=10):
     return ''.join(random.choice('abcdefghijklmnopqrstuvwxyz')
                    for x in range(length))
+
 
 class SampleTests(APITestCase):
 
@@ -140,8 +141,7 @@ class SampleTests(APITestCase):
         res = client.post('/samples/', sample_data)
         res_json = json.loads(res.content.decode('utf-8'))
 
-        updated_sample_number = get_random_str()
-        sample_data['number'] = updated_sample_number
+        sample_data['number'] = get_random_str()
         sample_data.update(dict(
             minerals=[
                 {
@@ -173,7 +173,5 @@ class SampleTests(APITestCase):
             HTTP_AUTHORIZATION='Token ' + self.inactive_user.auth_token.key
         )
 
-        sample_data = deepcopy(self.sample_data)
-
-        res = client.post('/samples/', sample_data)
+        res = client.post('/samples/', self.sample_data)
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
Allowing the caller to set an object’s owner doesn’t make sense.